### PR TITLE
Bump Spark version to 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Spark Connector for Hazelcast allows your Spark applications to connect to a Haz
 
 - Hazelcast 3.7.x
 - Apache Spark 1.6.1
+- Apache Spark 2.1.0 (Starting from v0.2)
 
 # Releases
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -5,7 +5,7 @@ import sbtassembly.AssemblyKeys._
 object Settings {
   val buildName = "hazelcast-spark"
   val buildVersion = "0.2-SNAPSHOT"
-  val buildScalaVersion = "2.10.6"
+  val buildScalaVersion = "2.11.8"
 
   val buildSettings = Defaults.coreDefaultSettings ++ Seq(
     name := buildName,

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,6 +1,6 @@
 object Versions {
   val hazelcastVersion = "3.7"
-  val sparkVersion = "1.6.1"
+  val sparkVersion = "2.1.0"
   val jcacheVersion = "1.0.0"
   val junitVersion = "4.12"
   val junitInterfaceVersion = "0.11"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.11
+sbt.version = 0.13.13

--- a/src/test/java/ReadFromHazelcastJavaTest.java
+++ b/src/test/java/ReadFromHazelcastJavaTest.java
@@ -7,13 +7,6 @@ import com.hazelcast.spark.connector.HazelcastSparkContext;
 import com.hazelcast.spark.connector.rdd.HazelcastJavaRDD;
 import com.hazelcast.spark.connector.util.HazelcastUtil;
 import com.hazelcast.test.HazelcastTestSupport;
-import java.io.Serializable;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -25,6 +18,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import scala.Tuple2;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -92,7 +94,7 @@ public class ReadFromHazelcastJavaTest extends HazelcastTestSupport {
     @Test
     public void countByKey() {
         HazelcastJavaRDD<Integer, Integer> hazelcastRDD = getPrepopulatedRDD();
-        Map<Integer, Object> map = hazelcastRDD.countByKey();
+        Map<Integer, Long> map = hazelcastRDD.countByKey();
         for (Object count : map.values()) {
             assertEquals(1L, count);
         }
@@ -159,8 +161,8 @@ public class ReadFromHazelcastJavaTest extends HazelcastTestSupport {
 
     private static class FlatMapValues implements FlatMapFunction<Tuple2<Integer, Integer>, Integer>, Serializable {
         @Override
-        public Iterable<Integer> call(Tuple2<Integer, Integer> integerIntegerTuple2) throws Exception {
-            return Collections.singletonList(integerIntegerTuple2._2());
+        public Iterator<Integer> call(Tuple2<Integer, Integer> integerIntegerTuple2) throws Exception {
+            return Collections.singletonList(integerIntegerTuple2._2()).iterator();
         }
     }
 


### PR DESCRIPTION
Upgrades Spark version to 2.1.0, (related https://github.com/hazelcast/hazelcast-spark/issues/4)
Since Spark is built with Scala 2.11 starting with version 2.0, Scala version is also upgraded to 2.11.8