### PR TITLE
Support for Spark 2.4.0 and above

### DIFF
--- a/src/main/scala/com/hazelcast/spark/connector/util/CleanupUtil.scala
+++ b/src/main/scala/com/hazelcast/spark/connector/util/CleanupUtil.scala
@@ -33,7 +33,7 @@ object CleanupUtil {
         this.synchronized {
           if (jobIds.contains(jobEnd.jobId)) {
             try {
-              val workers = sc.getConf.getInt("spark.executor.instances", sc.getExecutorStorageStatus.length)
+              val workers = sc.getConf.getInt("spark.executor.instances", sc.statusTracker.getExecutorInfos.length)
               val rddId: Option[Seq[Int]] = jobIds.get(jobEnd.jobId)
               if (rddId.isDefined) {
                 sc.parallelize(1 to workers, workers).setName(cleanupJobRddName).foreachPartition(it ⇒ closeAll(rddId.get))


### PR DESCRIPTION
PR closed by Hazelcast automation as no activity (>3 months). Please reopen with comments, if necessary. Thank you for using Hazelcast and your valuable contributions